### PR TITLE
Allow for forced deletion 

### DIFF
--- a/pypgrest/pypgrest.py
+++ b/pypgrest/pypgrest.py
@@ -70,10 +70,10 @@ class Postgrest(object):
             resource=resource, method="post", headers=headers, data=data
         )
 
-    def delete(self, resource, params=None, headers=None):
+    def delete(self, resource, params=None, headers=None, force=False):
         """This method is dangerous! It is possible to delete and modify records
         en masse. Read the PostgREST docs."""
-        if not params:
+        if not params and not force:
             raise Exception(
                 "You must supply parameters with delete requests. This is for your own protection."  # noqa E501
             )
@@ -83,7 +83,12 @@ class Postgrest(object):
         )
 
     def select(
-        self, *, resource, params=None, pagination=True, headers=None,
+        self,
+        *,
+        resource,
+        params=None,
+        pagination=True,
+        headers=None,
     ):
         """Fetch selected records from PostgREST. See documentation for horizontal
         and vertical filtering at http://postgrest.org/.

--- a/pypgrest/pypgrest.py
+++ b/pypgrest/pypgrest.py
@@ -75,7 +75,7 @@ class Postgrest(object):
         en masse. Read the PostgREST docs."""
         if not params and not force:
             raise Exception(
-                "You must supply parameters with delete requests. This is for your own protection."  # noqa E501
+                "You must supply parameters with delete requests. This is for your own protection. Providing force=True will override this exception."  # noqa E501
             )
         headers = self._get_request_headers(headers)
         return self._make_request(

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ def build_config(env, readme="README.md"):
         "name": package_name,
         "packages": setuptools.find_packages(),
         "url": "http://github.com/cityofaustin/pypgrest",
-        "version": "0.1.0",
+        "version": "0.2.0",
     }
 
 


### PR DESCRIPTION
Now merging into dev and is based on the dev branch!

Currently, the delete method will prevent you from deleting everything unless you provide parameters. This `force` argument will allow you to override this exception. 

Current behavior:

`client.delete(resource=table, params=None)`
> Exception: You must supply parameters with delete requests. This is for your own protection.

`client.delete(resource=table, params="literally anything!")`
> deletes everything in your `table` or based on the params you supply

New behavior:

`client.delete(resource=table, params=None)`
> Still: Exception: You must supply parameters with delete requests. This is for your own protection.

`client.delete(resource=table, params="literally anything!")`
> Still: deletes everything in your `table` or based on the params you supply

`client.delete(resource=table, params=None, force=True)`
> deletes everything in your `table`

`client.delete(resource=table, params=None, force=False)`
> Exception: You must supply parameters with delete requests. This is for your own protection.
